### PR TITLE
refactor: changed default Java package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Name | Description | Required | Default
 `server` | Server must be defined in yaml and selected when using the generator | Yes | -
 `user` | User for the server to generate code for. This can also be provided as an environment variable (see below) | No | app
 `password` | Password for the server to generate code for. This can also be provided as an environment variable (see below) | No | passw0rd
-`package` | Java package name for generated code | No | com.ibm.mq.samples.jms
+`package` | Java package name for generated code | No | com.asyncapi
 `mqTopicPrefix` | MQ topic prefix. Used for ibmmq protocols. Default will work with dev MQ instance | No | dev//
 `asyncapiFileDir` | Custom output location of the AsyncAPI file that you provided as an input | No | The root of the output directory
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       "package": {
         "description": "Java package name for generated code",
         "required": false,
-        "default": "com.ibm.mq.samples.jms"
+        "default": "com.asyncapi"
       },
       "mqTopicPrefix": {
         "description": "MQ topic prefix. Used for ibmmq protocols. Default will work with dev MQ instance",

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -31,4 +31,4 @@ RUN mvn compile &&\
     mvn package
 
 # Change this to the entrypoint for your application!
-CMD java -cp target/asyncapi-java-generator-0.1.0.jar com.ibm.mq.samples.jms.DemoSubscriber;
+CMD java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncpi.DemoSubscriber;

--- a/test/Common.test.js
+++ b/test/Common.test.js
@@ -181,5 +181,5 @@ test('ImportModels are generated', async () => {
   await generator.generateFromFile(path.resolve('test', yaml));
 
   expect(testCommon.ImportModels({asyncapi: generator.asyncapi, params: generator.templateParams})).toStrictEqual([`
-import com.ibm.mq.samples.jms.models.Song;`]);
+import com.asyncapi.models.Song;`]);
 });

--- a/test/Consumer.test.js
+++ b/test/Consumer.test.js
@@ -39,13 +39,13 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.annotation.JsonView;
 
-import com.ibm.mq.samples.jms.ConnectionHelper;
-import com.ibm.mq.samples.jms.LoggingHelper;
-import com.ibm.mq.samples.jms.Connection;
-import com.ibm.mq.samples.jms.PubSubBase;
+import com.asyncapi.ConnectionHelper;
+import com.asyncapi.LoggingHelper;
+import com.asyncapi.Connection;
+import com.asyncapi.PubSubBase;
 
-import com.ibm.mq.samples.jms.models.ModelContract;
-import com.ibm.mq.samples.jms.models.Song;
+import com.asyncapi.models.ModelContract;
+import com.asyncapi.models.Song;
 `
   );
 });

--- a/test/Producer.test.js
+++ b/test/Producer.test.js
@@ -68,11 +68,11 @@ import javax.jms.JMSRuntimeException;
 import javax.jms.ObjectMessage;
 
 
-import com.ibm.mq.samples.jms.ConnectionHelper;
-import com.ibm.mq.samples.jms.LoggingHelper;
-import com.ibm.mq.samples.jms.Connection;
-import com.ibm.mq.samples.jms.PubSubBase;
-import com.ibm.mq.samples.jms.models.ModelContract;
+import com.asyncapi.ConnectionHelper;
+import com.asyncapi.LoggingHelper;
+import com.asyncapi.Connection;
+import com.asyncapi.PubSubBase;
+import com.asyncapi.models.ModelContract;
 
 import com.fasterxml.jackson.databind.ObjectMapper; 
 import com.fasterxml.jackson.databind.ObjectWriter; 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -22,7 +22,7 @@ describe('template integration tests using the generator', () => {
     jest.setTimeout(30000);
   
     const OUTPUT_DIR = generateFolderName();
-    const PACKAGE = 'com.ibm.mq.samples.jms';
+    const PACKAGE = 'com.asyncapi';
     const PACKAGE_PATH = path.join(...PACKAGE.split('.'));
     const params = {
       server: 'production'
@@ -50,7 +50,7 @@ describe('template integration tests using the generator', () => {
     jest.setTimeout(30000);
   
     const OUTPUT_DIR = generateFolderName();
-    const PACKAGE = 'com.ibm.mq.samples.jms';
+    const PACKAGE = 'com.asyncapi';
     const PACKAGE_PATH = path.join(...PACKAGE.split('.'));
     const params = {
       server: 'production'
@@ -76,7 +76,7 @@ describe('template integration tests using the generator', () => {
     jest.setTimeout(30000);
   
     const OUTPUT_DIR = generateFolderName();
-    const PACKAGE = 'com.ibm.mq.samples.jms';
+    const PACKAGE = 'com.asyncapi';
     const PACKAGE_PATH = path.join(...PACKAGE.split('.'));
     const params = {
       server: 'production'

--- a/tutorials/IBMMQ.md
+++ b/tutorials/IBMMQ.md
@@ -52,17 +52,17 @@ These commands will allow you to run the Java Template publisher/subscriber mode
     ```
 5. Run your generated Subscriber
     ```
-    java -cp target/asyncapi-java-generator-0.1.0.jar com.ibm.mq.samples.jms.DemoSubscriber
+    java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoSubscriber
     ```
 6. In a seperate terminal, navigate to the `output` directory above and run your generated Publisher   
     ```
     cd ~/asyncapi-java-tutorial/output
-    java -cp target/asyncapi-java-generator-0.1.0.jar com.ibm.mq.samples.jms.DemoProducer
+    java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoProducer
     ```
 
 The messages will now be seen to be being sent from the running publisher to the running subscriber, using MQ topics. Your output from your subscriber should look something like
 ```
-Oct 14, 2021 9:53:23 AM com.ibm.mq.samples.jms.SingleReleasedSubscriber receive
+Oct 14, 2021 9:53:23 AM com.asyncapi.SingleReleasedSubscriber receive
 INFO: Received message: {
   “title” : “Hackathon”,
   “artist” : “Java”,
@@ -70,7 +70,7 @@ INFO: Received message: {
   “genre” : “Java”,
   “length” : 166
 }
-TYPE: com.ibm.mq.samples.jms.models.Single
+TYPE: com.asyncapi.models.Single
 ```
 
 ## Running with Docker

--- a/tutorials/KAFKA.md
+++ b/tutorials/KAFKA.md
@@ -52,17 +52,17 @@ These commands will allow you to run the Java Template publisher/subscriber mode
     ```
 5. Run your generated Subscriber
     ```
-    java -cp target/asyncapi-java-generator-0.1.0.jar com.ibm.mq.samples.jms.DemoSubscriber
+    java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoSubscriber
     ```
 6. In a seperate terminal, navigate to the `output` directory above and run your generated Publisher
     ```
     cd ~/asyncapi-java-tutorial/output
-    java -cp target/asyncapi-java-generator-0.1.0.jar com.ibm.mq.samples.jms.DemoProducer
+    java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoProducer
     ```
 
 The messages will now be seen to be being sent from the running publisher to the running subscriber, using Kafka topics. Your output from your subscriber should look something like
 ```
-Oct 14, 2021 9:53:23 AM com.ibm.mq.samples.jms.SingleReleasedSubscriber receive
+Oct 14, 2021 9:53:23 AM com.asyncapi.SingleReleasedSubscriber receive
 INFO: Received message: {
   “title” : “Hackathon”,
   “artist” : “Java”,
@@ -70,7 +70,7 @@ INFO: Received message: {
   “genre” : “Java”,
   “length” : 166
 }
-TYPE: com.ibm.mq.samples.jms.models.Single
+TYPE: com.asyncapi.models.Single
 ```
 
 ## Running with Docker


### PR DESCRIPTION
The Java template is evolved by supporting Apache Kafka other than IBM MQ (with JMS).
For this reason, I think that it does make more sense to have as default Java package for the generated code something more general like `com.asyncapi` (I see it being used in the Java Sprint template as well) instead of a more specific `com.ibm.mq.samples.jms` (IBM MQ with JMS). 
When using the template for Apache Kafka clients, having the generated code under `com.ibm.mq.samples.jms` by default sounds weird.
Of course, this can be changed providing the package as parameter to the generator but anyway having the current default package name doesn't seems to be right.