### PR TITLE
chore: minor tidying of generated README's

### DIFF
--- a/components/Readme/KafkaReadme.js
+++ b/components/Readme/KafkaReadme.js
@@ -10,7 +10,7 @@ For instructions on installing maven for your operating system, please see the [
 These commands will allow you to run the template publisher/subscriber model using Apache Kafka.
 
 1. Install dependencies
-\`\`\`sh
+    \`\`\`sh
     mvn compile
     \`\`\`
 
@@ -18,21 +18,21 @@ These commands will allow you to run the template publisher/subscriber model usi
 
 
 2. Create .jar package
-\`\`\`sh
+    \`\`\`sh
     mvn package
     \`\`\`
     Using maven generate the .jar file to run.
 
 3. Run Publisher
-\`\`\`sh
+    \`\`\`sh
     java -cp target/asyncapi-java-generator-0.1.0.jar: ${params.package}.DemoProducer
     \`\`\`
 
     This command runs the publisher function of this template from the generated .jar file.
 
 
-4. In a seperate terminal, Run Subscriber
-\`\`\`sh
+4. In a separate terminal, Run Subscriber
+    \`\`\`sh
     java -cp target/asyncapi-java-generator-0.1.0.jar: ${params.package}.DemoSubscriber
     \`\`\`
 

--- a/components/Readme/MQReadme.js
+++ b/components/Readme/MQReadme.js
@@ -7,36 +7,36 @@ ${asyncapi.info().description()}
 For instructions on installing maven for your operating system, please see the [Apache Maven site](https://maven.apache.org/install.html).
 
 ## Running the Publisher/Subscriber template
-These commands will allow you to run the template publisher/subscriber model using IBM MQ. 
+These commands will allow you to run the template publisher/subscriber model using IBM MQ.
 
 1. Install dependencies
-\`\`\`sh
-    mvn compile 
+    \`\`\`sh
+    mvn compile
     \`\`\`
 
     This command uses maven to install all the required dependences needed for this template to run.
 
 
 2. Create .jar package
-\`\`\`sh
+    \`\`\`sh
     mvn package
     \`\`\`
     Using maven generate the .jar file to run.
 
 3. Run Publisher
-\`\`\`sh
+    \`\`\`sh
     java -cp target/asyncapi-java-generator-0.1.0.jar: ${params.package}.DemoProducer
     \`\`\`
 
-    This command runs the publisher function of this template from the generated .jar file. 
+    This command runs the publisher function of this template from the generated .jar file.
 
 
-4. In a seperate terminal, Run Subscriber    
-\`\`\`sh
+4. In a separate terminal, Run Subscriber
+    \`\`\`sh
     java -cp target/asyncapi-java-generator-0.1.0.jar: ${params.package}.DemoSubscriber
     \`\`\`
 
-    This command runs the subscriber function of this template from the generated .jar file. 
+    This command runs the subscriber function of this template from the generated .jar file.
 
 
 The messages should now be sent from the running publisher to the running subscriber, using MQ topics.

--- a/tutorials/IBMMQ.md
+++ b/tutorials/IBMMQ.md
@@ -29,7 +29,7 @@ cd ~/asyncapi-java-tutorial
 ```
 
 ## Running the Publisher/Subscriber Template
-These commands will allow you to run the Java Template publisher/subscriber model using IBM MQ. 
+These commands will allow you to run the Java Template publisher/subscriber model using IBM MQ.
 1. Run the AsyncAPI Generator. <br>**Note:** You may need to change the username and password values if you have not followed the IBM MQ tutorial.
     ```
     ag https://ibm.biz/mq-asyncapi-yml-sample @asyncapi/java-template -o ./output -p server=production -p user=app -p password=passw0rd
@@ -44,7 +44,7 @@ These commands will allow you to run the Java Template publisher/subscriber mode
     ```
 3. Install the dependencies required to run this template
     ```
-    mvn compile 
+    mvn compile
     ```
 4. Create .jar package using maven
     ```
@@ -54,7 +54,7 @@ These commands will allow you to run the Java Template publisher/subscriber mode
     ```
     java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoSubscriber
     ```
-6. In a seperate terminal, navigate to the `output` directory above and run your generated Publisher   
+6. In a separate terminal, navigate to the `output` directory above and run your generated Publisher
     ```
     cd ~/asyncapi-java-tutorial/output
     java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoProducer
@@ -79,27 +79,27 @@ To deploy a dockerised instance of this project;
 1. Build the image
    ```
     docker build -t [PACKAGE_NAME]:[VERSION] .
-   ``` 
+   ```
 
 2. Run the image in detached mode
    ```
     docker run -d [PACKAGE_NAME]:[VERSION]
-   ``` 
+   ```
 
-Please note; The default `Dockerfile` included in output will only run `DemoSubscriber.java`. This will need to be replaced with the entrypoint to your application. 
+Please note; The default `Dockerfile` included in output will only run `DemoSubscriber.java`. This will need to be replaced with the entrypoint to your application.
 
 ### Networking
-Docker networking needs to be properly configured in order to allow your project to connect to an MQ instance. 
+Docker networking needs to be properly configured in order to allow your project to connect to an MQ instance.
 
 If MQ is also running in a docker container
 1. Create a docker network
    ```
     docker network create exampleMqNetwork
-   ``` 
+   ```
 2. Attach the docker network to your MQ container
    ```
     docker network connect exampleMqNetwork
-   ``` 
+   ```
 3. Update your env.json server hostname to match the container name for MQ. To find the name run
    ```
    docker ps

--- a/tutorials/KAFKA.md
+++ b/tutorials/KAFKA.md
@@ -54,7 +54,7 @@ These commands will allow you to run the Java Template publisher/subscriber mode
     ```
     java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoSubscriber
     ```
-6. In a seperate terminal, navigate to the `output` directory above and run your generated Publisher
+6. In a separate terminal, navigate to the `output` directory above and run your generated Publisher
     ```
     cd ~/asyncapi-java-tutorial/output
     java -cp target/asyncapi-java-generator-0.1.0.jar com.asyncapi.DemoProducer

--- a/utils/String.utils.js
+++ b/utils/String.utils.js
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 
-/* 
- * Converts from lowercase slash seperated to camel case java class names
+/*
+ * Converts from lowercase slash separated to camel case java class names
  */
 export function toJavaClassName(name) {
   const components = name.split((/[^A-Za-z0-9]/));


### PR DESCRIPTION
The markdown in the README we're generating is a bit off

<img width="898" alt="image" src="https://user-images.githubusercontent.com/1444788/196034814-8b2f9e9c-e147-4a10-bf62-578eb9fc7e55.png">

The indentation of the markdown code block characters in the generated readme wasn't quite right, which resulted in the code blocks not starting/ending correctly.

I also fixed a couple of minor spelling mistakes I spotted.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>