### PR TITLE
fix: correct conversion of AsyncAPI types into Java types

### DIFF
--- a/test/Types.utils.test.js
+++ b/test/Types.utils.test.js
@@ -6,25 +6,28 @@ const crypto = require('crypto');
 
 const MAIN_TEST_RESULT_PATH = path.join('test', 'temp', 'integrationTestResult');
 
-// Test class asyncApiTypeToJavaType
+// Test class asyncApiToJavaType
 test('Check integer type is converted to int', () => {
-  expect(typesUtils.asyncApiTypeToJavaType('integer')).toBe('int');
+  expect(typesUtils.asyncApiToJavaType('integer')).toBe('int');
+});
+test('Check int64 type is converted to long', () => {
+  expect(typesUtils.asyncApiToJavaType('integer', 'int64')).toBe('long');
 });
 
 test('Check string type is converted to String', () => {
-  expect(typesUtils.asyncApiTypeToJavaType('string')).toBe('String');
+  expect(typesUtils.asyncApiToJavaType('string')).toBe('String');
 });
 
 test('Check password type is converted to String', () => {
-  expect(typesUtils.asyncApiTypeToJavaType('password')).toBe('String');
+  expect(typesUtils.asyncApiToJavaType('string', 'password')).toBe('String');
 });
 
 test('Check byte type is not changed', () => {
-  expect(typesUtils.asyncApiTypeToJavaType('byte')).toBe('byte');
+  expect(typesUtils.asyncApiToJavaType('string', 'byte')).toBe('byte');
 });
 
 test('Unexpected type throws error', () => {
-  expect(() => { typesUtils.asyncApiTypeToJavaType('test');}).toThrow();
+  expect(() => { typesUtils.asyncApiToJavaType('test');}).toThrow();
 });
 
 // Test class setLocalVariables


### PR DESCRIPTION
I think the existing implementation was confusing "format" and "type", comparing the type property of AsyncAPI data objects with values that are supposed to be formats (e.g. "password").

I've reimplemented this based on the table in
https://www.asyncapi.com/docs/reference/specification/v2.5.0#dataTypeFormat

I'm using the optional format specifier where possible, as it's more specific - and if we can't find anything matching using that I'm falling back to the more general type specifier.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->