### PR TITLE
fix: allow overwriting existing directories

### DIFF
--- a/hooks/createFolderStructure.js
+++ b/hooks/createFolderStructure.js
@@ -25,7 +25,13 @@ async function createFolderStructure(generator) {
 
   const targetDir = generator.targetDir;
   const packageDir = targetDir + packagePath;
+  const modelDir = `${targetDir + packagePath}models`;
 
-  fs.mkdirSync(packageDir, {recursive: true});
-  fs.mkdirSync(`${targetDir + packagePath}models`);
+  if (!fs.existsSync(packageDir)) {
+    fs.mkdirSync(packageDir, {recursive: true});
+  }
+
+  if (!fs.existsSync(modelDir)) {
+    fs.mkdirSync(`${targetDir + packagePath}models`);
+  }
 }


### PR DESCRIPTION
**Description**
Test for existing directory structure in order to prevent failures when updating an existing application using the generator

**Related issue(s)**
Fixes #86