### PR TITLE
fix: correct invalid use of cases in switch

### DIFF
--- a/utils/Types.utils.js
+++ b/utils/Types.utils.js
@@ -133,13 +133,17 @@ export function asyncApiToDemoValue(type, format) {
   const boolWords = ['true', 'false'];
 
   switch (type) {
-  case ('integer' || 'long'):
+  case 'integer':
+  case 'long':
     return parseInt(Math.random() * 1000, 10);
 
-  case ('float' || 'double'):
+  case 'float':
+  case 'double':
     return Math.random();
 
-  case ('string' || 'binary' || 'password'):
+  case 'string':
+  case 'binary':
+  case 'password':
     if (format === 'uuid') {
       return 'UUID.randomUUID()';
     }
@@ -151,7 +155,8 @@ export function asyncApiToDemoValue(type, format) {
   case 'boolean':
     return boolWords[Math.floor(Math.random()*boolWords.length)];
 
-  case ('date' || 'dateTime'):
+  case 'date':
+  case 'dateTime':
     return (new Date()).toISOString().split('T')[0];
 
   default:


### PR DESCRIPTION
The use of OR's in switch isn't valid. 

For an example, try this in Node.js:

```js
const testvalue = 'option4';

switch (testvalue) {
    case ('option1' || 'option2'):
        console.log('1 or 2');
        break;
    case ('option3' || 'option4' || 'option5'):
        console.log('3, 4, or 5');
        break;
    default:
        console.log('unrecognised ' + testvalue)
}
```

This means we fail to recognise some type options. 