### PR TITLE
fix: populate env.json with valid Kafka bootstrap addresses

### DIFF
--- a/components/Common.js
+++ b/components/Common.js
@@ -109,6 +109,7 @@ public void close() {
 export function EnvJson({ asyncapi, params }) {
   const server = asyncapi.allServers().get(params.server);
   const url = server.url();
+  const hostname = server.host() || server.url();
   const protocol = server.protocol();
   let user = params.user;
   let password = params.password;
@@ -153,7 +154,7 @@ export function EnvJson({ asyncapi, params }) {
     return `
     {
       "KAFKA_ENDPOINTS": [{
-        "BOOTSTRAP_ADDRESS": "${url}",
+        "BOOTSTRAP_ADDRESS": "${hostname}",
         "APP_USER": "${user}",
         "APP_PASSWORD": "${password}"
       }]

--- a/test/Kafka.test.js
+++ b/test/Kafka.test.js
@@ -43,6 +43,11 @@ describe('kafka integration tests using the generator', () => {
     for (const expectedLine of expectedConnectionHelperLines) {
       expect(connectionHelper.includes(expectedLine)).toBe(true);
     }
+    const connectionEnv = readFileSync(path.join(OUTPUT_DIR, 'env.json'), 'utf-8');
+    const foundStreetlightsScram = connectionEnv.includes('"BOOTSTRAP_ADDRESS": "test.mykafkacluster.org:18092"');
+    const foundStreetlightsMtls = connectionEnv.includes('"BOOTSTRAP_ADDRESS": "test.mykafkacluster.org:28092"');
+    const foundRecordLabelKafka = connectionEnv.includes('"BOOTSTRAP_ADDRESS": "my-kafka-hostname:9092"');
+    expect(foundStreetlightsScram || foundStreetlightsMtls || foundRecordLabelKafka).toBe(true);
 
     return true;
   };


### PR DESCRIPTION
The generator was putting the "kafka-secure://" protocol prefix in the bootstrap address for generated Kafka apps, which the Kafka client library rejects as an invalid URL.

This commit uses the hostname if it is available (v3 docs) but falls back to using the url otherwise (v2 docs).
