### PR TITLE
chore: update Java version in generated pom files

### DIFF
--- a/components/PomHelper.js
+++ b/components/PomHelper.js
@@ -63,8 +63,8 @@ export function PomHelper({ server, params }) {
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <src.dir>.</src.dir>
   </properties>
 


### PR DESCRIPTION
Source option 7 is no longer supported, so I'm increasing it to java 8 so we can at least run maven builds with generated code.

