### PR TITLE
fix: add missing import that prevents compiling generated code

### DIFF
--- a/components/Files/Models.js
+++ b/components/Files/Models.js
@@ -33,6 +33,7 @@ export function Models(asyncapi, params) {
         <PackageDeclaration path={`${params.package}.models`} />
         <ImportDeclaration path={`${params.package}.models.ModelContract`} />
         <ImportDeclaration path={'java.util.UUID'} />
+        <ImportDeclaration path={'com.fasterxml.jackson.annotation.JsonProperty'} />
 
         <Class name={messageNameUpperCase} extendsClass="ModelContract">
           <Indent size={2} type={IndentationTypes.SPACES}>


### PR DESCRIPTION
`@JsonProperty` annotations can be added to some instance variables in the model class, but this breaks maven builds because JsonProperty is missing from the imports.
