### PR TITLE
fix: update version of Node.js used in release workflows

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -48,7 +48,7 @@ jobs:
         name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'
@@ -85,7 +85,7 @@ jobs:
         name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
         run: npm install


### PR DESCRIPTION
The last few release workflows have failed with errors such as

Cannot find module 'ajv/dist/compile/codegen' from
     'node_modules/ajv-errors/dist/index.js'

Require stack:
  node_modules/ajv-errors/dist/index.js
  node_modules/@smoya/multi-parser/node_modules/parserapiv1/...
  node_modules/@smoya/multi-parser/cjs/parse.js
  node_modules/@smoya/multi-parser/cjs/index.js
  node_modules/@asyncapi/generator/lib/parser.js
  node_modules/@asyncapi/generator/lib/templateConfigValidator.js
  node_modules/@asyncapi/generator/lib/generator.js

This has been happening since we updated java-template to the newer version of @asyncapi/generator

The simplest workaround seems to be to update to a newer version of Node.js.
