### PR TITLE
fix logging initialization for kafka consumer generated code

### DIFF
--- a/components/Consumer/KafkaConsumer.js
+++ b/components/Consumer/KafkaConsumer.js
@@ -18,6 +18,7 @@ import { toJavaClassName } from '../../utils/String.utils';
 export function ConsumerDeclaration() {
   return `
   private KafkaConsumer consumer = null;
+  private static final Logger logger = Logger.getLogger(${toJavaClassName('YourConsumerClass')}.class.getName());
     `;
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR addresses a critical issue with logging in the generated Kafka consumer code. Previously, calls to `logger.info(...)` were made without a properly defined logger, which would cause compile-time errors. The fix introduces a standard logger initialization in the consumer declaration:
```java
private static final Logger logger = Logger.getLogger(YourConsumerClass.class.getName());
```
This change ensures that all logging calls have a valid reference, aligning with Java best practices for logging. While this PR resolves the logging issue, please note that placeholders like `recordFailure(ex)` and the reference to `ch` (used in the consumer constructor) are still present and will need to be addressed in subsequent updates

**Related issue(s)**
Fixes #241 